### PR TITLE
Housekeeping 3

### DIFF
--- a/R/gg_diagnose.R
+++ b/R/gg_diagnose.R
@@ -7,7 +7,6 @@
 #' @param plot.all logical; determine whether plot will be returned as
 #' an arranged grid. When set to false, the function
 #' will return a list of diagnostic plots. Parameter defaults to TRUE.
-#' @param mode specify the set of graphics to be returned: "base_r", "all" (the default) 
 #' @param mode A string. Specifies which set of diagnostic plots to return:
 #'   * `all` (the default)
 #'   * `base_r`: only graphs included in the base R `plot(lm(...))` (i.e. residual vs fitted, QQ plot, scale location, residual vs leverage)

--- a/R/gg_diagnose.R
+++ b/R/gg_diagnose.R
@@ -30,15 +30,15 @@
 #' @import ggplot2
 #' @importFrom gridExtra grid.arrange
 #' @importFrom stats fitted formula hatvalues qchisq qnorm quantile residuals rstandard
-gg_diagnose <- function(fitted.lm, theme = NULL, ncol = NA, to.plot = "all", 
+gg_diagnose <- function(fitted.lm, theme = NULL, ncol = NA, plot.all = TRUE, mode = "all",
                         scale.factor = 0.5, boxcox = FALSE, max.per.page = NA) 
    {
 
    handle_exception(fitted.lm, "gg_diagnose")
   
-   if(!(tolower(to.plot) %in% c("all", "base_r", "list"))) {
-     to.plot = "all"
-     message("`to.plot` defaulting to 'all': incorrect value supplied in function call.")
+   if(!(plot.all %in% c(TRUE, FALSE, "base_r"))) {
+     plot.all = TRUE
+     message("`plot.all` defaulting to TRUE: incorrect value supplied in function call.")
    }
 
    plots = list()
@@ -66,18 +66,18 @@ gg_diagnose <- function(fitted.lm, theme = NULL, ncol = NA, to.plot = "all",
       message("Maximum plots per page invalid; switch to default")
       max.per.page = length(plots)
    }
+   
+   if (mode == "base_r") {
+     plots = plots[c("res_fitted","qqplot","scalelocation","resleverage")]
+   } else if (mode != "all") {
+     message("`mode` has invalid value, using 'all'")
+   }
   
    # determine to plot the plots, or return a list of plots
-   if (all(tolower(to.plot)=="all")) {
-      return(arrange.plots(plots, max.per.page, ncol))
-   }
-   
-   if (all(tolower(to.plot)=="base_r")) {
-     return(arrange.plots(plots[c(4,3,5,6)], max.per.page, ncol))
-   }
-   
-   if (all(tolower(to.plot)=="list")) {
-      return(plots)
+   if (plot.all == TRUE) {
+     return(arrange.plots(plots, max.per.page, ncol))
+   } else {
+     return (plots)
    }
 
 }

--- a/R/gg_diagnose.R
+++ b/R/gg_diagnose.R
@@ -1,5 +1,4 @@
 
-
 #' Plot all diagnostic plots given fitted linear regression line.
 #'
 #' @param fitted.lm lm object that contains fitted regression
@@ -31,11 +30,16 @@
 #' @import ggplot2
 #' @importFrom gridExtra grid.arrange
 #' @importFrom stats fitted formula hatvalues qchisq qnorm quantile residuals rstandard
-gg_diagnose <- function(fitted.lm, theme = NULL, ncol = NA, plot.all = TRUE, 
+gg_diagnose <- function(fitted.lm, theme = NULL, ncol = NA, to.plot = "all", 
                         scale.factor = 0.5, boxcox = FALSE, max.per.page = NA) 
    {
 
    handle_exception(fitted.lm, "gg_diagnose")
+  
+   if(!(tolower(to.plot) %in% c("all", "base_r", "list"))) {
+     to.plot = "all"
+     message("`to.plot` defaulting to 'all': incorrect value supplied in function call.")
+   }
 
    plots = list()
    # get all plots
@@ -62,13 +66,18 @@ gg_diagnose <- function(fitted.lm, theme = NULL, ncol = NA, plot.all = TRUE,
       message("Maximum plots per page invalid; switch to default")
       max.per.page = length(plots)
    }
-
+  
    # determine to plot the plots, or return a list of plots
-   if (plot.all) {
+   if (all(tolower(to.plot)=="all")) {
       return(arrange.plots(plots, max.per.page, ncol))
    }
-   else {
-      return (plots)
+   
+   if (all(tolower(to.plot)=="base_r")) {
+     return(arrange.plots(plots[c(4,3,5,6)], max.per.page, ncol))
+   }
+   
+   if (all(tolower(to.plot)=="list")) {
+      return(plots)
    }
 
 }

--- a/R/gg_diagnose.R
+++ b/R/gg_diagnose.R
@@ -7,6 +7,10 @@
 #' @param plot.all logical; determine whether plot will be returned as
 #' an arranged grid. When set to false, the function
 #' will return a list of diagnostic plots. Parameter defaults to TRUE.
+#' @param mode specify the set of graphics to be returned: "base_r", "all" (the default) 
+#' @param mode A string. Specifies which set of diagnostic plots to return:
+#'   * `all` (the default)
+#'   * `base_r`: only graphs included in the base R `plot(lm(...))` (i.e. residual vs fitted, QQ plot, scale location, residual vs leverage)
 #' @param scale.factor numeric; scales the point size, linewidth, labels in all diagnostic plots to allow optimal viewing. Defaults to 0.5.
 #' @param boxcox logical; detemine whether boxcox plot will be included. Parameter defaults to FALSE.
 #' @param max.per.page numeric; maximum number of plots allowed in one page.

--- a/R/gg_scalelocation.R
+++ b/R/gg_scalelocation.R
@@ -28,5 +28,5 @@ gg_scalelocation <- function(fitted.lm, method = 'loess', scale.factor = 1, se =
               geom_point(size = scale.factor) +
               geom_smooth(method = method, se = se, size = scale.factor, color = "indianred3") +
               ggtitle("Scale-Location Plot") +
-              labs(x="Sqrt(Standardized Residuals)", y = "Fitted Values"))
+              labs(x="Fitted Values", y = "Sqrt (Standardized Residuals)"))
 }


### PR DESCRIPTION
**Bugfix:**
* Reverse x and y-axis labels in scale location plot

**Feature:**
* Add `mode` parameter in `gg_diagnose`, which could be of value `base_r` and `all` (the default). If set to `base_r`, `gg_diagnose` returns a set of diagnostic plots similar to that returned by base R graphics (i.e. residual vs fitted, QQ plot, scale location, and residual vs leverage)